### PR TITLE
feat: add border radius to subtitles background

### DIFF
--- a/lib/src/subtitles/better_player_subtitles_configuration.dart
+++ b/lib/src/subtitles/better_player_subtitles_configuration.dart
@@ -55,6 +55,9 @@ class BetterPlayerSubtitlesConfiguration {
   ///Background color of the subtitle
   final Color backgroundColor;
 
+  ///Border radius of the subtitle background
+  final BorderRadiusGeometry backgroundBorderRadius;
+
   const BetterPlayerSubtitlesConfiguration({
     this.fontSize = 14,
     this.fontColor = Colors.white,
@@ -73,6 +76,7 @@ class BetterPlayerSubtitlesConfiguration {
     this.useSafeArea = true,
     this.paddingAnimationDuration = const Duration(milliseconds: 300),
     this.paddingAnimationCurve = Curves.easeInOut,
+    this.backgroundBorderRadius = BorderRadius.zero,
   });
 
   @override
@@ -95,7 +99,8 @@ class BetterPlayerSubtitlesConfiguration {
         playerHeight == other.playerHeight &&
         useSafeArea == other.useSafeArea &&
         paddingAnimationDuration == other.paddingAnimationDuration &&
-        paddingAnimationCurve == other.paddingAnimationCurve;
+        paddingAnimationCurve == other.paddingAnimationCurve &&
+        backgroundBorderRadius == other.backgroundBorderRadius;
   }
 
   @override
@@ -117,5 +122,6 @@ class BetterPlayerSubtitlesConfiguration {
         useSafeArea,
         paddingAnimationDuration,
         paddingAnimationCurve,
+        backgroundBorderRadius,
       );
 }

--- a/lib/src/subtitles/better_player_subtitles_drawer.dart
+++ b/lib/src/subtitles/better_player_subtitles_drawer.dart
@@ -18,12 +18,10 @@ class BetterPlayerSubtitlesDrawer extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _BetterPlayerSubtitlesDrawerState createState() =>
-      _BetterPlayerSubtitlesDrawerState();
+  _BetterPlayerSubtitlesDrawerState createState() => _BetterPlayerSubtitlesDrawerState();
 }
 
-class _BetterPlayerSubtitlesDrawerState
-    extends State<BetterPlayerSubtitlesDrawer> {
+class _BetterPlayerSubtitlesDrawerState extends State<BetterPlayerSubtitlesDrawer> {
   final RegExp htmlRegExp = RegExp(r"<[^>]*>", multiLine: true);
   late TextStyle _innerTextStyle;
   late TextStyle _outerTextStyle;
@@ -80,8 +78,7 @@ class _BetterPlayerSubtitlesDrawerState
   @override
   void didUpdateWidget(covariant BetterPlayerSubtitlesDrawer oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.betterPlayerSubtitlesConfiguration !=
-        widget.betterPlayerSubtitlesConfiguration) {
+    if (oldWidget.betterPlayerSubtitlesConfiguration != widget.betterPlayerSubtitlesConfiguration) {
       _initializeConfiguration();
     }
     if (oldWidget.betterPlayerController != widget.betterPlayerController) {
@@ -117,8 +114,7 @@ class _BetterPlayerSubtitlesDrawerState
   void _updateState() {
     if (mounted) {
       setState(() {
-        _latestValue =
-            widget.betterPlayerController.videoPlayerController!.value;
+        _latestValue = widget.betterPlayerController.videoPlayerController!.value;
       });
     }
   }
@@ -128,10 +124,9 @@ class _BetterPlayerSubtitlesDrawerState
     final BetterPlayerSubtitle? subtitle = _getSubtitleAtCurrentPosition();
     widget.betterPlayerController.renderedSubtitle = subtitle;
     final List<String> subtitles = subtitle?.texts ?? [];
-    final List<Widget> textWidgets =
-        subtitles.map((text) => _buildSubtitleTextWidget(text)).toList();
+    final List<Widget> textWidgets = subtitles.map((text) => _buildSubtitleTextWidget(text)).toList();
 
-    return SizedBox.expand(
+    return SizedBox(
       child: SafeArea(
         bottom: _configuration!.useSafeArea,
         left: _configuration!.useSafeArea,
@@ -162,8 +157,7 @@ class _BetterPlayerSubtitlesDrawerState
     }
 
     final Duration position = _latestValue!.position;
-    for (final BetterPlayerSubtitle subtitle
-        in widget.betterPlayerController.subtitlesLines) {
+    for (final BetterPlayerSubtitle subtitle in widget.betterPlayerController.subtitlesLines) {
       if (subtitle.start! <= position && subtitle.end! >= position) {
         return subtitle;
       }
@@ -172,21 +166,28 @@ class _BetterPlayerSubtitlesDrawerState
   }
 
   Widget _buildSubtitleTextWidget(String subtitleText) {
-    return Row(
-      children: [
-        Expanded(
-          child: Align(
-            alignment: _configuration!.alignment,
-            child: _getTextWithStroke(subtitleText),
+    return Center(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Align(
+              alignment: _configuration!.alignment,
+              child: _getTextWithStroke(subtitleText),
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 
   Widget _getTextWithStroke(String subtitleText) {
     return Container(
-      color: _configuration!.backgroundColor,
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      decoration: BoxDecoration(
+        color: _configuration!.backgroundColor,
+        borderRadius: _configuration!.backgroundBorderRadius,
+      ),
       child: Stack(
         children: [
           if (_configuration!.outlineEnabled)


### PR DESCRIPTION
Main change:
- add border radius to subtitles background

Side change:
- added 4px padding between the subtitles text and subtitles background. This is hard coded but I feel this is a fair enough stylistic choice to have in the lib rather than implement a new parameter?